### PR TITLE
Ajout d'un fichier .desktop

### DIFF
--- a/ressources/6pm.desktop
+++ b/ressources/6pm.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=6 PM
+GenericName=synthesizer
+GenericName[fr]=synthétiseur
+Comment=Phase modulation (PM) synthesizer made of six oscillators.
+Comment[fr]=Synthétiseur par modulation de phase (PM) fait à partir de 6 oscillateurs.
+Exec=6pm
+Terminal=false
+Icon=icon
+Type=Application
+Categories=AudioVideo;Audio;


### PR DESCRIPTION
Ce fichier permet d'intégrer proprement le logiciel dans les menus des environnements de bureau (KDE, Gnome, MATE, Xfce, ...). Il contient notamment une traduction en français qui permet une définition lors du survol de l'icône dans le menu.
Testé sous MATE, ça fonctionne nickel.

J'ai mis ce fichier dans un dossier "ressources" pour faciliter l'organisation de tes sources. En tant qu'empaqueteur, j'apprécie cela car ça me permet rapidement de repérer où sont les fichiers utiles à l'intégration dans une distribution. Je prévois d'ajouter d'autres fichiers ici pour cela plus tard.
